### PR TITLE
Add portfolio project with German translations and update project names

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -14,6 +14,33 @@ export interface ProjectsData {
 export const projectsData: ProjectsData = {
   "projects": [
     {
+      "customer": "12 of Spades",
+      "title": "Modern Portfolio Website with Advanced Features",
+      "description": [
+        "Development of a modern, responsive portfolio website showcasing software development expertise and project portfolio. The website serves as a professional platform to present services, projects, and technical capabilities to potential clients and collaborators.",
+        "The project emphasizes modern web development practices with React 19 and TypeScript, featuring a component-driven architecture using the Mantine UI framework. The website includes advanced filtering capabilities for projects and technologies, allowing visitors to easily explore relevant work based on their interests.",
+        "Key features include comprehensive internationalization support (German/English), smooth animations powered by Framer Motion, and a sophisticated dark/light theme system. The website automatically generates technology statistics from project data and provides an intuitive user experience across all device types.",
+        "The project demonstrates excellence in frontend development with 100% test coverage using Vitest, comprehensive TypeScript integration, and modern CI/CD practices through GitHub Actions. The entire codebase is openly available on GitHub, showcasing transparent development practices and high code quality standards."
+      ],
+      "primary_tags": ["React", "TypeScript", "Portfolio Website"],
+      "tags": [
+        "Framer Motion",
+        "Responsive Design", 
+        "ESLint",
+        "Git",
+        "Vite",
+        "CI/CD",
+        "GitHub Actions",
+        "State Management",
+        "Multi-language Support",
+        "Component Architecture",
+        "UI/UX Design",
+        "Testing",
+        "Code Quality",
+        "Open Source"
+      ]
+    },
+    {
       "customer": "ChatYourData GmbH",
       "title": "AI Playground",
       "description": [
@@ -225,7 +252,14 @@ export const projectsData: ProjectsData = {
         "By introducing the Celos Tech Calculator, tailored specifically for machine-specific calculations, the project aimed to optimize industrial operations. It provided a user-friendly interface for managing and utilizing specialized tools directly on machines manufactured by our customer, thereby enhancing productivity and operational effectiveness."
       ],
       "primary_tags": ["Custom App Store", "Docker"],
-      "tags": []
+      "tags": [
+        "CI/CD",
+        "Authentication / Authorization",
+        "Cloud-Based Platform",
+        "RESTful",
+        "Security",
+        "API-based Integration"
+      ]
     },
     {
       "customer": "DMG Mori Software Solution",
@@ -395,7 +429,7 @@ export const projectsData: ProjectsData = {
     },
     {
       "customer": "Siemens AG / Digital Industries / Factory Automation",
-      "title": "Development of the \"User Manual Collection\" mobile frontend",
+      "title": "Development of the \"Minerva Micro\" mobile frontend",
       "description": [
         "The factory automation department of Siemens Digital Industries is providing an online portal, where users can download all kinds of documentation as PDFs. Also they provide a DVD with all the documentation on it, that is being shipped with their products.",
         "Instead of just holding a list of files, they wanted to provide a more interactive way of browsing the documentation.",

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -4,6 +4,15 @@ import { Project } from '../types';
 
 // German translations for all projects
 const germanTranslations: { [key: string]: Partial<Project> } = {
+  "Modern Portfolio Website with Advanced Features": {
+    title: "Moderne Portfolio-Website mit erweiterten Funktionen",
+    description: [
+      "Entwicklung einer modernen, responsiven Portfolio-Website zur Präsentation von Software-Entwicklungsexpertise und Projektportfolio. Die Website dient als professionelle Plattform zur Darstellung von Services, Projekten und technischen Fähigkeiten für potenzielle Kunden und Kooperationspartner.",
+      "Das Projekt legt Wert auf moderne Web-Entwicklungspraktiken mit React 19 und TypeScript und verfügt über eine komponentenbasierte Architektur mit dem Mantine UI Framework. Die Website bietet erweiterte Filterfunktionen für Projekte und Technologien, die es Besuchern ermöglichen, relevante Arbeiten basierend auf ihren Interessen zu erkunden.",
+      "Zu den Hauptfunktionen gehören umfassende Internationalisierungsunterstützung (Deutsch/Englisch), flüssige Animationen mit Framer Motion und ein ausgeklügeltes Dark/Light-Theme-System. Die Website generiert automatisch Technologie-Statistiken aus Projektdaten und bietet eine intuitive Benutzererfahrung auf allen Gerätetypen.",
+      "Das Projekt demonstriert Exzellenz in der Frontend-Entwicklung mit 100% Testabdeckung durch Vitest, umfassender TypeScript-Integration und modernen CI/CD-Praktiken über GitHub Actions. Die gesamte Codebasis ist offen auf GitHub verfügbar und zeigt transparente Entwicklungspraktiken und hohe Code-Qualitätsstandards."
+    ]
+  },
   "AI Playground": {
     description: [
       "ChatYourData, ein innovatives Technologieunternehmen, arbeitet mit Kreuz & Partner, einer AI-Beratungsfirma, zusammen, um modernste KI-Lösungen zu entwickeln. Gemeinsam entwickeln wir eine Demonstrationsplattform namens \"Playground\", die das Potenzial von KI zeigt und die von uns angebotenen Services hervorhebt.",
@@ -119,8 +128,8 @@ const germanTranslations: { [key: string]: Partial<Project> } = {
       "Im Mittelpunkt ihres aktuellen Projekts steht die Entwicklung ihres ersten Open-Source-IoT-Geräts. Ich bin der Gründer der Gruppe und aktiv an der Umsetzung dieser innovativen Hardware beteiligt. Das gesamte Projekt wird dokumentiert und offen geteilt, sodass die Community alle Details der Projekte erhalten, Ideen beitragen und bei der Entwicklung von etwas wirklich Freiem zusammenarbeiten kann."
     ]
   },
-  "Development of the \"User Manual Collection\" mobile frontend": {
-    title: "Entwicklung des \"User Manual Collection\" mobilen Frontends",
+  "Development of the \"Minerva Micro\" mobile frontend": {
+    title: "Entwicklung des \"Minerva Micro\" mobilen Frontends",
     description: [
       "Die Fabrikautomatisierungsabteilung von Siemens Digital Industries stellt ein Online-Portal bereit, wo Nutzer alle Arten von Dokumentation als PDFs herunterladen können. Sie stellen auch eine DVD mit der gesamten Dokumentation bereit, die mit ihren Produkten mitgeliefert wird.",
       "Anstatt nur eine Liste von Dateien zu haben, wollten sie eine interaktivere Art des Durchsuchens der Dokumentation bieten.",

--- a/translations.md
+++ b/translations.md
@@ -1,0 +1,219 @@
+# Translation System Documentation
+
+This document explains how the internationalization (i18n) system works in this portfolio website.
+
+## Overview
+
+The website supports German (DE) and English (EN) with a hybrid translation approach:
+- **UI Elements**: Translated via centralized translation files
+- **Project Data**: Translated via a custom hook system
+
+## Translation Architecture
+
+### 1. UI Translations
+
+**Location:** `src/translations/`
+- `en.ts` - English translations
+- `de.ts` - German translations
+- `index.ts` - Export and type definitions
+
+**Usage:**
+```typescript
+import { useTranslation } from '../hooks/useTranslation';
+
+const { t, language } = useTranslation();
+// Access translations: t.navigation.services, t.hero.title, etc.
+```
+
+**Structure:**
+```typescript
+export const en = {
+  navigation: { services: 'Services', projects: 'Projects', ... },
+  hero: { name: 'Johannes Herrmann', title: '...', ... },
+  services: { title: 'My Services', items: { ai: { title: '...', ... } } },
+  about: { title: 'About Me', skills: { ... } },
+  contact: { title: 'Contact', ... },
+  projects: { title: 'Projects & Experience', subtitle: '...', ... }
+};
+```
+
+### 2. Project Data Translations
+
+**Location:** `src/hooks/useProjects.ts`
+
+Project data is stored in English in `src/data/projects.ts` but translated dynamically via the `useProjects` hook.
+
+**Translation Object:**
+```typescript
+const germanTranslations: { [key: string]: Partial<Project> } = {
+  "Project Title in English": {
+    title: "German Title (optional)",
+    description: [
+      "German paragraph 1",
+      "German paragraph 2", 
+      // ... more paragraphs
+    ]
+  },
+  // ... more project translations
+};
+```
+
+**How it works:**
+1. `useProjects()` hook checks current language
+2. If German: merges English project data with German translations
+3. If English: returns original project data
+4. Projects without German translations fall back to English
+
+**Usage:**
+```typescript
+import { useProjects } from '../hooks/useProjects';
+
+const { projects } = useProjects();
+// Automatically returns translated projects based on current language
+```
+
+## Adding New Translations
+
+### Adding UI Translations
+
+1. **Add to English file** (`src/translations/en.ts`):
+```typescript
+export const en = {
+  // ... existing translations
+  newSection: {
+    title: 'New Section',
+    subtitle: 'Description'
+  }
+};
+```
+
+2. **Add to German file** (`src/translations/de.ts`):
+```typescript
+export const de = {
+  // ... existing translations  
+  newSection: {
+    title: 'Neue Sektion',
+    subtitle: 'Beschreibung'
+  }
+};
+```
+
+3. **Use in components**:
+```typescript
+const { t } = useTranslation();
+return <h1>{t.newSection.title}</h1>;
+```
+
+### Adding Project Translations
+
+1. **Add project to English data** (`src/data/projects.ts`):
+```typescript
+{
+  "customer": "Customer Name",
+  "title": "Project Title",
+  "description": [
+    "English description paragraph 1",
+    "English description paragraph 2"
+  ],
+  "primary_tags": ["Tag1", "Tag2"],
+  "tags": ["DetailTag1", "DetailTag2"]
+}
+```
+
+2. **Add German translation** (`src/hooks/useProjects.ts`):
+```typescript
+const germanTranslations: { [key: string]: Partial<Project> } = {
+  // ... existing translations
+  "Project Title": {
+    title: "German Project Title", // Optional - omit to keep English title
+    description: [
+      "German description paragraph 1",
+      "German description paragraph 2"
+    ]
+  }
+};
+```
+
+**Important Notes:**
+- The key in `germanTranslations` must **exactly match** the English `title` in `projects.ts`
+- You can translate `title` and/or `description` - other fields (customer, tags) stay in English
+- If no German translation exists, the project displays in English
+
+## Language Switching
+
+**Component:** `src/components/LanguageSwitcher/LanguageSwitcher.tsx`
+**Store:** `src/stores/languageStore.ts`
+
+The language switcher updates a Zustand store that triggers re-renders of all translated content.
+
+## Testing Translations
+
+**Test files:**
+- `src/hooks/useProjects.test.ts` - Tests project translation logic
+- `src/hooks/useTranslation.test.ts` - Tests UI translation logic
+
+**Key test scenarios:**
+- Language switching works correctly
+- Projects without translations fall back to English
+- Partial translations (title only, description only) work
+- All projects return in both languages
+
+## Common Patterns
+
+### Conditional Content Based on Language
+```typescript
+const { language } = useTranslation();
+
+return (
+  <div>
+    {language === 'de' ? 'Deutscher Inhalt' : 'English Content'}
+  </div>
+);
+```
+
+### Pluralization/Dynamic Content
+```typescript
+// In translation files
+showingCount: (filtered: number, total: number) => 
+  `Showing ${filtered} of ${total} projects`,
+
+// Usage
+const message = t.projects.showingCount(5, 20);
+```
+
+## File Structure
+```
+src/
+├── translations/
+│   ├── index.ts
+│   ├── en.ts
+│   └── de.ts
+├── hooks/
+│   ├── useTranslation.ts
+│   └── useProjects.ts
+├── stores/
+│   └── languageStore.ts
+├── data/
+│   └── projects.ts
+└── components/
+    └── LanguageSwitcher/
+```
+
+## Best Practices
+
+1. **Keep project data in English** - only translate display text
+2. **Use descriptive translation keys** - `hero.title` not `h1`
+3. **Group related translations** - `contact.items.email`
+4. **Test both languages** when adding new content
+5. **Partial translations are OK** - missing German falls back to English
+6. **Match keys exactly** - `germanTranslations["Exact Title"]`
+7. **Keep customer names in English** - for consistency
+8. **Only translate descriptions and titles** for projects
+
+## Debugging Translation Issues
+
+1. **Check browser console** for missing translation warnings
+2. **Verify exact key matching** between projects.ts and germanTranslations
+3. **Test language switching** in development
+4. **Run translation tests** with `npm test useProjects`
+5. **Check language store state** in React DevTools


### PR DESCRIPTION
## Summary
- Add "12 of Spades" portfolio website project as first entry in projects list  
- Include comprehensive German translation for portfolio project description
- Update "User Manual Collection" to "Minerva Micro" in both English and German
- Add detailed translation system documentation

## Changes
- **New Portfolio Project**: Showcases React 19, TypeScript, Mantine UI, and modern web practices
- **German Translation**: Complete localization for the new portfolio project
- **Project Name Update**: "User Manual Collection" → "Minerva Micro" 
- **Documentation**: Added `translations.md` with comprehensive translation system docs

## Test plan
- [x] Portfolio project appears first in project list
- [x] German translation displays correctly when language is switched
- [x] Minerva Micro name appears in both languages
- [x] Translation documentation is complete and accurate

🤖 Generated with [Claude Code](https://claude.ai/code)