### PR TITLE
Add MIT License for open source distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Johannes Herrmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
• Add MIT License to enable open source distribution
• Follow "do whatever you want but don't involve my name" philosophy  
• Copyright assigned to Johannes Herrmann

## Changes Made
• **LICENSE**: Add standard MIT License text with proper attribution
• Enable unrestricted use, modification, and distribution
• Provide legal framework for open source contributions

## License Benefits
• **Commercial Use**: ✅ Allowed
• **Private Use**: ✅ Allowed  
• **Modification**: ✅ Allowed
• **Distribution**: ✅ Allowed
• **Liability**: ❌ Not provided
• **Warranty**: ❌ Not provided

## Philosophy
Follows the "do whatever you want but don't involve my name" approach while maintaining proper attribution requirements.

## Test Plan
- [x] License file follows standard MIT format
- [x] Proper copyright attribution included
- [x] Enables open source ecosystem participation

🤖 Generated with [Claude Code](https://claude.ai/code)