### PR TITLE
Fix mobile navigation background color inconsistency

### DIFF
--- a/src/components/Navigation/ImprovedNavigation.tsx
+++ b/src/components/Navigation/ImprovedNavigation.tsx
@@ -247,7 +247,10 @@ export const ImprovedNavigation = () => {
           body: {
             padding: '1.5rem',
             backgroundColor: 'var(--background-primary)'
-          }
+          },
+          content: {
+            backgroundColor: 'var(--background-primary)'
+          },
         }}
       >
         <Stack gap="lg">


### PR DESCRIPTION
## Summary
- Fixed inconsistent background colors in mobile navigation drawer
- The drawer content had different background color than header/body sections
- Added explicit `content` background styling to match other sections

## Test plan
- [ ] Open mobile navigation on various devices/screen sizes
- [ ] Verify consistent background color throughout drawer
- [ ] Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)