### PR TITLE
Improve tag styling and spacing consistency

### DIFF
--- a/src/components/Filter/TagChip.module.css
+++ b/src/components/Filter/TagChip.module.css
@@ -1,0 +1,3 @@
+.tagChip {
+  text-transform: none !important;
+}

--- a/src/components/Filter/TagChip.tsx
+++ b/src/components/Filter/TagChip.tsx
@@ -1,5 +1,6 @@
 import { Badge, type BadgeProps } from '@mantine/core';
 import { motion, Variants } from 'framer-motion';
+import styles from './TagChip.module.css';
 
 interface TagChipProps extends Omit<BadgeProps, 'onClick'> {
   tag: string;
@@ -41,6 +42,7 @@ export const TagChip = ({
         radius="xl"
         variant={isSelected ? 'filled' : 'outline'}
         color={isPrimary ? 'red' : 'orange'}
+        className={styles.tagChip}
         style={{
           cursor: onClick ? 'pointer' : 'default',
           ...props.style

--- a/src/components/Projects/TagList.tsx
+++ b/src/components/Projects/TagList.tsx
@@ -9,6 +9,7 @@ interface TagListProps {
   secondaryTags: string[];
   maxTags?: number;
   fontSize?: string;
+  lineHeight?: number;
   showMoreBadge?: boolean;
   selectable?: boolean;
 }
@@ -18,6 +19,7 @@ export const TagList = ({
   secondaryTags, 
   maxTags = 100, 
   fontSize = '0.8rem',
+  lineHeight,
   showMoreBadge = true,
   selectable = true
 }: TagListProps) => {
@@ -45,7 +47,7 @@ export const TagList = ({
   };
 
   return (
-    <Group gap="xs">
+    <Group gap={8} style={{ rowGap: 0 }}>
       {displayedTags.map(({ tag, isPrimary }) => (
         <motion.div
           key={`${isPrimary ? 'primary' : 'secondary'}-${tag}`}
@@ -57,7 +59,11 @@ export const TagList = ({
             isPrimary={isPrimary}
             isSelected={selectable ? selectedTags.includes(tag) : false}
             onClick={() => handleTagClick(tag)}
-            style={{ cursor: selectable ? 'pointer' : 'default', fontSize }}
+            style={{ 
+              cursor: selectable ? 'pointer' : 'default', 
+              fontSize,
+              lineHeight: 1
+            }}
           />
         </motion.div>
       ))}

--- a/src/components/Services/SimpleServices.tsx
+++ b/src/components/Services/SimpleServices.tsx
@@ -4,6 +4,7 @@ import { motion, Variants, useReducedMotion } from 'framer-motion';
 import { Section, Grid } from '../Layout';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
 import { useTranslation } from '../../hooks/useTranslation';
+import { TagList } from '../Projects/TagList';
 // import aiImage from '../../assets/ai-development.webp';
 // import cloudImage from '../../assets/cloud-architecture.webp';
 // import fullstackImage from '../../assets/fullstack-development.webp';
@@ -174,24 +175,13 @@ export const SimpleServices = () => {
                   <Text size="sm" fw={600} c="var(--text-primary)">
                     {t.services.technologies}
                   </Text>
-                  <Box style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-                    {service.technologies.map((tech) => (
-                      <Text
-                        key={tech}
-                        size="xs"
-                        px="xs"
-                        py={4}
-                        style={{
-                          backgroundColor: 'var(--neutral-light)',
-                          borderRadius: '12px',
-                          color: 'var(--text-secondary)',
-                          fontWeight: 500
-                        }}
-                      >
-                        {tech}
-                      </Text>
-                    ))}
-                  </Box>
+                  <TagList
+                    primaryTags={service.technologies}
+                    secondaryTags={[]}
+                    showMoreBadge={false}
+                    selectable={false}
+                    fontSize="0.75rem"
+                  />
                   </Stack>
                 </Stack>
                 </Card>


### PR DESCRIPTION
## Summary
- Replace simple Text components with TagChip components in Services section
- Override Mantine Badge uppercase styling with CSS module for proper case display
- Improve TagList spacing with 8px horizontal gap and 0px vertical gap for better density
- Standardize tag appearance between Projects and Services sections

## Test plan
- [ ] Verify service technology tags display in proper case (not UPPERCASE)
- [ ] Check consistent styling between project and service tags
- [ ] Test responsive layout with improved tag spacing
- [ ] Validate tag hover animations work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)