### PR TITLE
feat: add StackOverflow profile link and improve social links text

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -1,5 +1,5 @@
 import { Stack, Title, Text, Group, Button, Anchor, Divider, Box } from '@mantine/core';
-import { IconMail, IconPhone, IconBrandLinkedin, IconBrandGithub, IconMapPin } from '@tabler/icons-react';
+import { IconMail, IconPhone, IconBrandLinkedin, IconBrandGithub, IconBrandStackoverflow, IconMapPin } from '@tabler/icons-react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useState } from 'react';
 import { Section } from '../Layout';
@@ -65,6 +65,11 @@ export const Contact = () => {
       icon: IconBrandGithub,
       label: 'GitHub',
       href: 'https://github.com/woozar'
+    },
+    {
+      icon: IconBrandStackoverflow,
+      label: 'StackOverflow',
+      href: 'https://stackoverflow.com/users/3914932/woozar'
     }
   ];
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -78,7 +78,7 @@ export const de = {
   contact: {
     title: 'Kontakt',
     subtitle: 'Bereit für Ihr nächstes Projekt? Lassen Sie uns über Ihre Anforderungen sprechen und gemeinsam innovative Lösungen entwickeln.',
-    followMe: 'Folgen Sie mir',
+    followMe: 'Finden Sie mich auch hier',
     contactItems: {
       email: 'E-Mail',
       phone: 'Telefon',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -78,7 +78,7 @@ export const en = {
   contact: {
     title: 'Contact',
     subtitle: 'Ready for your next project? Let\'s discuss your requirements and develop innovative solutions together.',
-    followMe: 'Follow Me',
+    followMe: 'Find me also on',
     contactItems: {
       email: 'Email',
       phone: 'Phone',


### PR DESCRIPTION
## Summary
- Add StackOverflow profile link to contact section social links
- Improve social links text to sound more professional and less influencer-like
- Update translations for better user experience

## Changes Made
### ✅ StackOverflow Profile Integration
- Added StackOverflow profile link: https://stackoverflow.com/users/3914932/woozar
- Imported `IconBrandStackoverflow` from @tabler/icons-react
- Integrated with existing social links styling and animations
- Opens in new tab with proper security attributes (`rel="noopener noreferrer"`)

### ✅ Translation Improvements
- **German**: "Folgen Sie mir" → "Finden Sie mich auch hier"
- **English**: "Follow Me" → "Find me also on"
- More professional tone that better fits a freelancer profile

### ✅ Technical Implementation
- Maintains consistent styling with LinkedIn and GitHub links
- Follows existing component patterns and accessibility standards
- Responsive design preserved across all screen sizes

## Test Results
- ✅ All tests passing: 604/604
- ✅ Linting successful: No ESLint errors
- ✅ Build successful: TypeScript compilation and Vite build complete
- ✅ Pre-commit hooks working: Automatic quality checks passed

## Visual Changes
The StackOverflow link appears alongside LinkedIn and GitHub in the contact section with:
- Consistent button styling and hover animations
- Professional orange theme colors
- Proper icon and label display
- Mobile-responsive layout

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)