### PR TITLE
feat: increase default container width to xl (1280px) for more desktop space

### DIFF
--- a/src/components/Layout/Container.tsx
+++ b/src/components/Layout/Container.tsx
@@ -7,7 +7,7 @@ interface ContainerProps {
   className?: string;
 }
 
-export const Container = ({ children, size = 'lg', className }: ContainerProps) => {
+export const Container = ({ children, size = 'xl', className }: ContainerProps) => {
   const maxWidths = {
     sm: '640px',
     md: '768px',

--- a/src/components/Layout/Section.test.tsx
+++ b/src/components/Layout/Section.test.tsx
@@ -134,7 +134,7 @@ describe('Section', () => {
     // The content should be wrapped in a container with centered styling
     const container = screen.getByText('Content').parentElement
     expect(container).toHaveStyle({
-      maxWidth: '1024px',
+      maxWidth: '1280px',
       margin: '0 auto'
     })
   })

--- a/src/components/Layout/Section.tsx
+++ b/src/components/Layout/Section.tsx
@@ -15,7 +15,7 @@ export const Section = ({
   id, 
   className,
   paddingY,
-  containerSize = 'lg'
+  containerSize = 'xl'
 }: SectionProps) => {
   const paddings = {
     sm: '2rem 0',


### PR DESCRIPTION
## Summary
- Changes default Container component size from 'lg' (1024px) to 'xl' (1280px)
- Changes default Section component containerSize from 'lg' to 'xl' 
- Updates corresponding test expectations

## Motivation
Modern desktop monitors have significantly more horizontal space than the current 1024px default. Increasing to 1280px provides more room for content while maintaining responsive behavior on smaller screens.

## Changes Made
- `Container.tsx`: Changed default size prop from 'lg' to 'xl'
- `Section.tsx`: Changed default containerSize prop from 'lg' to 'xl'  
- `Section.test.tsx`: Updated test expectations to match new 1280px width

## Test Plan
- [x] All existing tests pass with updated expectations
- [x] Layout functions correctly across different screen sizes
- [x] Mobile and tablet views remain unaffected (use responsive padding)
- [x] Linter and build pass successfully

## Technical Details
The xl size was already configured to 1280px in the Container component's maxWidths object, so this change only updates the default values to use the existing xl configuration.

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)