### PR TITLE
feat: update email addresses to hyphenated domain format

### DIFF
--- a/impressum.txt
+++ b/impressum.txt
@@ -5,6 +5,6 @@ Feldweiher 9
 91085 Weisendorf(Buch)
 
 Telefon: +49 176 8100 1371
-E-Mail: info@12ofspades.com
+E-Mail: info@12-of-spades.com
 Umsatzsteuer-Identifikationsnummer nach §27a Umsatzsteuergesetz: DE323916092
 

--- a/src/components/Contact/Contact.test.tsx
+++ b/src/components/Contact/Contact.test.tsx
@@ -57,7 +57,7 @@ describe("Contact", () => {
     render(<Contact />);
 
     expect(screen.getByText("E-Mail")).toBeInTheDocument();
-    expect(screen.getByText("info@12ofspades.com")).toBeInTheDocument();
+    expect(screen.getByText("info@12-of-spades.com")).toBeInTheDocument();
 
     expect(screen.getByText("Telefon")).toBeInTheDocument();
     expect(screen.getByText("+49 176 8100 1371")).toBeInTheDocument();
@@ -69,8 +69,8 @@ describe("Contact", () => {
   it("should render contact links with correct hrefs", () => {
     render(<Contact />);
 
-    const emailLink = screen.getByText("info@12ofspades.com").closest("a");
-    expect(emailLink).toHaveAttribute("href", "mailto:info@12ofspades.com");
+    const emailLink = screen.getByText("info@12-of-spades.com").closest("a");
+    expect(emailLink).toHaveAttribute("href", "mailto:info@12-of-spades.com");
 
     const phoneLink = screen.getByText("+49 176 8100 1371").closest("a");
     expect(phoneLink).toHaveAttribute("href", "tel:+4917681001371");
@@ -175,7 +175,7 @@ describe("Contact", () => {
 
     // Should still render all content on mobile
     expect(screen.getByText("Kontakt")).toBeInTheDocument();
-    expect(screen.getByText("info@12ofspades.com")).toBeInTheDocument();
+    expect(screen.getByText("info@12-of-spades.com")).toBeInTheDocument();
     expect(screen.getByText("LinkedIn")).toBeInTheDocument();
   });
 
@@ -251,7 +251,7 @@ describe("Contact", () => {
 
       // Component should render successfully with animations enabled
       expect(screen.getByText("Kontakt")).toBeInTheDocument();
-      expect(screen.getByText("info@12ofspades.com")).toBeInTheDocument();
+      expect(screen.getByText("info@12-of-spades.com")).toBeInTheDocument();
     });
 
     it("should render with reduced motion animations when reduced motion is true", () => {
@@ -261,7 +261,7 @@ describe("Contact", () => {
 
       // Component should render successfully with reduced animations
       expect(screen.getByText("Kontakt")).toBeInTheDocument();
-      expect(screen.getByText("info@12ofspades.com")).toBeInTheDocument();
+      expect(screen.getByText("info@12-of-spades.com")).toBeInTheDocument();
       expect(screen.getByText("LinkedIn")).toBeInTheDocument();
     });
 

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -64,8 +64,8 @@ export const Contact = () => {
     {
       icon: IconMail,
       label: t.contact.contactItems.email,
-      value: "info@12ofspades.com",
-      href: "mailto:info@12ofspades.com",
+      value: "info@12-of-spades.com",
+      href: "mailto:info@12-of-spades.com",
     },
     {
       icon: IconPhone,

--- a/src/components/Modal/LegalModal.test.tsx
+++ b/src/components/Modal/LegalModal.test.tsx
@@ -157,7 +157,7 @@ describe("LegalModal", () => {
       expect(screen.getByText("Feldweiher 9")).toBeInTheDocument();
       expect(screen.getByText("91085 Weisendorf(Buch)")).toBeInTheDocument();
       expect(screen.getByText("+49 176 8100 1371")).toBeInTheDocument();
-      expect(screen.getByText("info@12ofspades.com")).toBeInTheDocument();
+      expect(screen.getByText("info@12-of-spades.com")).toBeInTheDocument();
     });
 
     it("should render impressum tax information", () => {

--- a/src/components/Modal/LegalModal.tsx
+++ b/src/components/Modal/LegalModal.tsx
@@ -112,7 +112,7 @@ export const LegalModal = ({ opened, onClose, type }: LegalModalProps) => {
                 <strong>Telefon:</strong> +49 176 8100 1371
               </Text>
               <Text>
-                <strong>E-Mail:</strong> info@12ofspades.com
+                <strong>E-Mail:</strong> info@12-of-spades.com
               </Text>
             </Stack>
 

--- a/src/components/SEO/SEOHead.tsx
+++ b/src/components/SEO/SEOHead.tsx
@@ -139,7 +139,7 @@ export const SEOHead = ({
         addressLocality: "Weisendorf",
         addressCountry: "DE",
       },
-      email: "info@12ofspades.com",
+      email: "info@12-of-spades.com",
       telephone: "+49 176 8100 1371",
     });
 

--- a/src/components/Workshops/WorkshopLandingPage.test.tsx
+++ b/src/components/Workshops/WorkshopLandingPage.test.tsx
@@ -63,7 +63,6 @@ const mockTranslations = {
       subtitle:
         "Maximum AI value with minimal effort. Let us identify and pick the low hanging fruits in your company together.",
       ctaButton: "Get in Touch",
-      ctaSubtext: "Non-binding inquiry - workshops@12ofspades.com",
     },
     problem: {
       title: "The Challenge",
@@ -396,7 +395,7 @@ describe("WorkshopLandingPage", () => {
     fireEvent.click(contactButton);
 
     // Should have set mailto link
-    expect(window.location.href).toContain("mailto:workshops@12ofspades.com");
+    expect(window.location.href).toContain("mailto:workshops@12-of-spades.com");
     expect(window.location.href).toContain("Workshop%20Anfrage");
   });
 

--- a/src/components/Workshops/WorkshopLandingPage.tsx
+++ b/src/components/Workshops/WorkshopLandingPage.tsx
@@ -77,7 +77,7 @@ Bitte kontaktieren Sie mich für ein unverbindliches Gespräch.
 
 Viele Grüße`);
 
-    window.location.href = `mailto:workshops@12ofspades.com?subject=${subject}&body=${body}`;
+    window.location.href = `mailto:workshops@12-of-spades.com?subject=${subject}&body=${body}`;
   };
 
   return (

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -230,7 +230,6 @@ export const de = {
       subtitle:
         "Maximaler AI-Nutzen mit minimalem Aufwand. Lassen Sie uns gemeinsam die Low Hanging Fruits in Ihrem Unternehmen identifizieren und gemeinsam pflücken - bevor Sie über aufwändige Projekte nachdenken, die sich spät oder nie bezahlt machen.",
       ctaButton: "Kontakt aufnehmen",
-      ctaSubtext: "Unverbindliche Anfrage - workshops@12ofspades.com",
     },
     problem: {
       title: "Die Herausforderungen",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -229,7 +229,6 @@ export const en = {
       subtitle:
         "Maximum AI value with minimal effort. Let us together identify and strategically harvest the Low Hanging Fruits in your company - before you consider expensive projects that pay off late or never.",
       ctaButton: "Get in Touch",
-      ctaSubtext: "Non-binding inquiry - workshops@12ofspades.com",
     },
     problem: {
       title: "The Challenges",


### PR DESCRIPTION
## Summary
- Update all email addresses to use hyphenated domain format
- General contact: `info@12-of-spades.com` (was `info@12ofspades.com`)
- Workshop inquiries: `workshops@12-of-spades.com` (was `workshops@12ofspades.com`)
- Remove unused ctaSubtext translation keys

## Test plan
- [x] All tests pass (637/637)
- [x] Linting passes
- [x] Build succeeds
- [x] Email addresses updated across all components
- [x] Translation files cleaned up

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)