### PR TITLE
feat: add reusable CtaButton component

### DIFF
--- a/src/components/CtaButton.tsx
+++ b/src/components/CtaButton.tsx
@@ -1,0 +1,134 @@
+import { ReactNode } from "react";
+
+import { Button, ButtonProps } from "@mantine/core";
+
+import { IconMail } from "@tabler/icons-react";
+
+import { useTranslation } from "@/hooks/useTranslation";
+
+interface CtaButtonProps {
+  onClick?: () => void;
+  variant?: "desktop" | "mobile" | "hero" | "card";
+  isTablet?: boolean;
+  children?: ReactNode;
+  leftSection?: ReactNode;
+  size?: ButtonProps["size"];
+  fullWidth?: boolean;
+  component?: "button" | "a";
+  href?: string;
+}
+
+export const CtaButton = ({
+  onClick,
+  variant = "desktop",
+  isTablet = false,
+  children,
+  leftSection,
+  size,
+  fullWidth = false,
+  component = "button",
+  href,
+}: CtaButtonProps) => {
+  const { t } = useTranslation();
+
+  const defaultIcon = leftSection ?? (
+    <IconMail size={variant === "mobile" ? 16 : variant === "hero" ? 20 : 18} />
+  );
+  const buttonText = children ?? t.navigation.contact;
+
+  // Mobile variant (small button for mobile nav)
+  if (variant === "mobile") {
+    return (
+      <Button
+        component={component}
+        href={href}
+        variant="filled"
+        size="sm"
+        leftSection={defaultIcon}
+        style={{
+          background:
+            "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
+          border: "none",
+          borderRadius: "1.5rem",
+        }}
+        onClick={onClick}
+      >
+        {buttonText}
+      </Button>
+    );
+  }
+
+  // Hero variant (large button for hero section)
+  if (variant === "hero") {
+    return (
+      <Button
+        component={component}
+        href={href}
+        size={size ?? "lg"}
+        variant="filled"
+        leftSection={defaultIcon}
+        style={{
+          background:
+            "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
+          border: "none",
+          fontSize: "1rem",
+        }}
+        onClick={onClick}
+      >
+        {buttonText}
+      </Button>
+    );
+  }
+
+  // Card variant (for workshop cards and similar)
+  if (variant === "card") {
+    return (
+      <Button
+        component={component}
+        href={href}
+        size={size ?? "md"}
+        fullWidth={fullWidth}
+        style={{
+          background:
+            "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
+          border: "none",
+        }}
+        onClick={onClick}
+      >
+        {buttonText}
+      </Button>
+    );
+  }
+
+  // Desktop variant (default for desktop nav)
+  return (
+    <Button
+      component={component}
+      href={href}
+      variant="filled"
+      leftSection={defaultIcon}
+      style={{
+        background:
+          "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
+        border: "none",
+        fontSize: isTablet ? "0.85rem" : "0.9rem",
+        fontWeight: 600,
+        padding: isTablet ? "0.5rem 1rem" : "0.6rem 1.2rem",
+        borderRadius: "2rem",
+        boxShadow: "0 4px 15px rgba(255, 107, 53, 0.3)",
+        transition: "all 0.2s ease",
+      }}
+      styles={{
+        root: {
+          "&:hover": {
+            transform: "translateY(-2px)",
+            boxShadow: "0 6px 20px rgba(255, 107, 53, 0.4)",
+          },
+        },
+      }}
+      onClick={onClick}
+    >
+      {buttonText}
+    </Button>
+  );
+};

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Group, Image, Stack, Text, Title } from "@mantine/core";
 
-import { IconDownload, IconMail } from "@tabler/icons-react";
+import { IconDownload } from "@tabler/icons-react";
 
 import { Variants, motion } from "framer-motion";
 
@@ -9,6 +9,7 @@ import { useModal } from "@/hooks/useModal";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { useTranslation } from "@/hooks/useTranslation";
 
+import { CtaButton } from "../CtaButton.tsx";
 import { Section } from "../Layout";
 
 // import heroPortrait from '../../assets/hero-portrait.webp';
@@ -181,20 +182,12 @@ export const Hero = () => {
                   whileHover="hover"
                   whileTap="tap"
                 >
-                  <Button
-                    size="lg"
-                    variant="filled"
-                    leftSection={<IconMail size={20} />}
-                    style={{
-                      background:
-                        "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
-                      border: "none",
-                      fontSize: "1rem",
-                    }}
+                  <CtaButton
+                    variant="hero"
                     onClick={() => handleNavClick("#contact")}
                   >
                     {t.hero.contactButton}
-                  </Button>
+                  </CtaButton>
                 </motion.div>
 
                 <motion.div

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -12,7 +12,7 @@ import {
   Text,
 } from "@mantine/core";
 
-import { IconFileText, IconMail } from "@tabler/icons-react";
+import { IconFileText } from "@tabler/icons-react";
 
 import { useLocation } from "react-router-dom";
 
@@ -20,6 +20,7 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useModal } from "@/hooks/useModal";
 import { useTranslation } from "@/hooks/useTranslation";
 
+import { CtaButton } from "../CtaButton.tsx";
 import { LanguageSwitcher } from "../LanguageSwitcher";
 import { Container } from "../Layout";
 import { ThemeSwitcher } from "../ThemeSwitcher";
@@ -196,6 +197,13 @@ export const Navigation = () => {
                   </Anchor>
                 ))}
 
+                {/* CTA Button */}
+                <CtaButton
+                  onClick={() => handleNavClick("#contact")}
+                  variant="desktop"
+                  isTablet={isTablet}
+                />
+
                 {/* Theme & Language Switchers */}
                 {!isTablet && (
                   <Group gap="xs">
@@ -203,34 +211,6 @@ export const Navigation = () => {
                     <LanguageSwitcher variant="desktop" />
                   </Group>
                 )}
-
-                {/* CTA Button */}
-                <Button
-                  variant="filled"
-                  leftSection={<IconMail size={18} />}
-                  style={{
-                    background:
-                      "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
-                    border: "none",
-                    fontSize: isTablet ? "0.85rem" : "0.9rem",
-                    fontWeight: 600,
-                    padding: isTablet ? "0.5rem 1rem" : "0.6rem 1.2rem",
-                    borderRadius: "2rem",
-                    boxShadow: "0 4px 15px rgba(255, 107, 53, 0.3)",
-                    transition: "all 0.2s ease",
-                  }}
-                  styles={{
-                    root: {
-                      "&:hover": {
-                        transform: "translateY(-2px)",
-                        boxShadow: "0 6px 20px rgba(255, 107, 53, 0.4)",
-                      },
-                    },
-                  }}
-                  onClick={() => handleNavClick("#contact")}
-                >
-                  {t.navigation.contact}
-                </Button>
               </Group>
             )}
 
@@ -238,20 +218,10 @@ export const Navigation = () => {
             {isMobile && (
               <Group gap="md" align="center">
                 {/* Mobile CTA */}
-                <Button
-                  variant="filled"
-                  size="sm"
-                  leftSection={<IconMail size={16} />}
-                  style={{
-                    background:
-                      "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
-                    border: "none",
-                    borderRadius: "1.5rem",
-                  }}
+                <CtaButton
                   onClick={() => handleNavClick("#contact")}
-                >
-                  {t.navigation.contact}
-                </Button>
+                  variant="mobile"
+                />
 
                 <Burger
                   opened={drawerOpened}

--- a/src/components/Workshops/WorkshopsOverview.test.tsx
+++ b/src/components/Workshops/WorkshopsOverview.test.tsx
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useReducedMotion } from "framer-motion";
+
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useTranslation } from "@/hooks/useTranslation";
+import { fireEvent, render, screen } from "@/test/test-utils";
+import { de } from "@/translations/de";
+
+import { WorkshopsOverview } from "./WorkshopsOverview";
+
+// Mock dependencies
+vi.mock("@/hooks/useMediaQuery");
+vi.mock("@/hooks/useTranslation");
+
+const mockUseMediaQuery = vi.mocked(useMediaQuery);
+const mockUseTranslation = vi.mocked(useTranslation);
+
+describe("WorkshopsOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMediaQuery.mockReturnValue({
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+    });
+    mockUseTranslation.mockReturnValue({
+      t: de,
+      language: "de",
+    });
+    vi.mocked(useReducedMotion).mockReturnValue(false);
+
+    // Mock scrollTo
+    Object.defineProperty(window, "scrollTo", {
+      value: vi.fn(),
+      writable: true,
+    });
+
+    // Mock querySelector
+    Object.defineProperty(document, "querySelector", {
+      value: vi.fn().mockReturnValue({
+        offsetTop: 500,
+      } as HTMLElement),
+      writable: true,
+    });
+  });
+
+  it("should render workshops section with title and subtitle", () => {
+    render(<WorkshopsOverview />);
+
+    expect(screen.getByText("Workshops & Training")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Vom Quick Win zur Strategie – praktisches KI-Know-how für Ihr Team"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should render both workshop cards", () => {
+    render(<WorkshopsOverview />);
+
+    expect(screen.getByText("AI Low Hanging Fruits")).toBeInTheDocument();
+    expect(
+      screen.getByText("KI als Werkzeug – Strategie-Training")
+    ).toBeInTheDocument();
+  });
+
+  it("should render workshop types and durations", () => {
+    render(<WorkshopsOverview />);
+
+    expect(screen.getByText("Praktischer Workshop")).toBeInTheDocument();
+    expect(screen.getByText("Strategie-Workshop")).toBeInTheDocument();
+    expect(screen.getByText("1-3 Tage")).toBeInTheDocument();
+    expect(screen.getByText("0,5-1 Tag")).toBeInTheDocument();
+  });
+
+  it("should render workshop descriptions", () => {
+    render(<WorkshopsOverview />);
+
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes("sofort umsetzbare KI-Anwendungen") &&
+          content.includes("Maximaler Nutzen")
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes("wann KI Sinn macht") &&
+          content.includes("teure Fehlinvestitionen")
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should render workshop highlights", () => {
+    render(<WorkshopsOverview />);
+
+    expect(
+      screen.getByText("Konkrete Use Cases aus Ihrem Alltag")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Hands-on mit echten Tools")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sofort umsetzbare Ergebnisse")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Entscheidungs-Framework für KI-Projekte")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Reale Fallbeispiele und Lessons Learned")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("ROI-Bewertung von KI-Vorhaben")
+    ).toBeInTheDocument();
+  });
+
+  it("should render correct CTAs for available and coming soon workshops", () => {
+    render(<WorkshopsOverview />);
+
+    const workshopButtons = screen.getAllByRole("link");
+    expect(workshopButtons[0]).toHaveTextContent("Zum Workshop");
+
+    const contactButtons = screen.getAllByRole("button");
+    const interestButton = contactButtons.find((btn) =>
+      btn.textContent?.includes("Interesse? Kontakt")
+    );
+    expect(interestButton).toBeInTheDocument();
+  });
+
+  it("should render Coming Soon badge for strategy workshop", () => {
+    render(<WorkshopsOverview />);
+
+    expect(screen.getByText("Coming Soon")).toBeInTheDocument();
+  });
+
+  it("should render with proper semantic structure", () => {
+    render(<WorkshopsOverview />);
+
+    const mainTitle = screen.getByRole("heading", { level: 2 });
+    expect(mainTitle).toHaveTextContent("Workshops & Training");
+
+    const workshopHeadings = screen.getAllByRole("heading", { level: 3 });
+    expect(workshopHeadings).toHaveLength(2);
+    expect(workshopHeadings[0]).toHaveTextContent("AI Low Hanging Fruits");
+    expect(workshopHeadings[1]).toHaveTextContent(
+      "KI als Werkzeug – Strategie-Training"
+    );
+  });
+
+  it("should adapt layout for mobile devices", () => {
+    mockUseMediaQuery.mockReturnValue({
+      isMobile: true,
+      isTablet: false,
+      isDesktop: false,
+    });
+
+    render(<WorkshopsOverview />);
+
+    expect(screen.getByText("Workshops & Training")).toBeInTheDocument();
+    expect(screen.getByText("AI Low Hanging Fruits")).toBeInTheDocument();
+  });
+
+  it("should have proper link for available workshop", () => {
+    render(<WorkshopsOverview />);
+
+    const workshopLink = screen.getByRole("link", { name: /Zum Workshop/i });
+    expect(workshopLink).toHaveAttribute(
+      "href",
+      "/workshops/ai-low-hanging-fruits"
+    );
+  });
+
+  describe("Animation and Reduced Motion", () => {
+    it("should render with normal animations when reduced motion is false", () => {
+      vi.mocked(useReducedMotion).mockReturnValue(false);
+
+      render(<WorkshopsOverview />);
+
+      expect(screen.getByText("Workshops & Training")).toBeInTheDocument();
+      expect(screen.getByText("AI Low Hanging Fruits")).toBeInTheDocument();
+    });
+
+    it("should render with reduced motion animations when reduced motion is true", () => {
+      vi.mocked(useReducedMotion).mockReturnValue(true);
+
+      render(<WorkshopsOverview />);
+
+      expect(screen.getByText("Workshops & Training")).toBeInTheDocument();
+      expect(
+        screen.getByText("KI als Werkzeug – Strategie-Training")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should render workshops in correct order", () => {
+    render(<WorkshopsOverview />);
+
+    const workshopHeadings = screen.getAllByRole("heading", { level: 3 });
+
+    expect(workshopHeadings[0]).toHaveTextContent("AI Low Hanging Fruits");
+    expect(workshopHeadings[1]).toHaveTextContent(
+      "KI als Werkzeug – Strategie-Training"
+    );
+  });
+
+  it("should have proper section structure", () => {
+    render(<WorkshopsOverview />);
+
+    const workshopsSection = screen
+      .getByText("Workshops & Training")
+      .closest("section");
+    expect(workshopsSection).toBeInTheDocument();
+  });
+
+  it("should handle contact button click for unavailable workshop", () => {
+    render(<WorkshopsOverview />);
+
+    const contactButtons = screen.getAllByRole("button");
+    const interestButton = contactButtons.find((btn) =>
+      btn.textContent?.includes("Interesse? Kontakt")
+    );
+
+    expect(interestButton).toBeInTheDocument();
+    fireEvent.click(interestButton!);
+
+    expect(document.querySelector).toHaveBeenCalledWith("#contact");
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 400, // 500 - 100 (header height)
+      behavior: "smooth",
+    });
+  });
+
+  it("should handle missing contact section gracefully", () => {
+    document.querySelector = vi.fn().mockReturnValue(null);
+
+    render(<WorkshopsOverview />);
+
+    const contactButtons = screen.getAllByRole("button");
+    const interestButton = contactButtons.find((btn) =>
+      btn.textContent?.includes("Interesse? Kontakt")
+    );
+
+    expect(() => fireEvent.click(interestButton!)).not.toThrow();
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Workshops/WorkshopsOverview.tsx
+++ b/src/components/Workshops/WorkshopsOverview.tsx
@@ -1,0 +1,233 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  List,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from "@mantine/core";
+
+import { IconCheck } from "@tabler/icons-react";
+
+import { Variants, motion } from "framer-motion";
+
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { useTranslation } from "@/hooks/useTranslation";
+
+import { CtaButton } from "../CtaButton.tsx";
+import { Grid, Section } from "../Layout";
+
+export const WorkshopsOverview = () => {
+  const { isMobile } = useMediaQuery();
+  const { t } = useTranslation();
+  const shouldReduceMotion = useReducedMotion();
+
+  const itemVariants: Variants = {
+    hidden: {
+      opacity: shouldReduceMotion ? 1 : 0,
+      y: shouldReduceMotion ? 0 : 30,
+    },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: shouldReduceMotion ? {} : { duration: 0.6, ease: "easeOut" },
+    },
+  };
+
+  const cardVariants: Variants = {
+    hidden: {
+      opacity: shouldReduceMotion ? 1 : 0,
+      y: shouldReduceMotion ? 0 : 40,
+      scale: shouldReduceMotion ? 1 : 0.95,
+    },
+    visible: {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: shouldReduceMotion ? {} : { duration: 0.6, ease: "easeOut" },
+    },
+  };
+
+  const handleContactClick = () => {
+    const contactSection = document.querySelector("#contact");
+    if (contactSection) {
+      const headerHeight = 100;
+      const elementPosition =
+        (contactSection as HTMLElement).offsetTop - headerHeight;
+      window.scrollTo({
+        top: elementPosition,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  return (
+    <Section id="workshops">
+      <Stack gap="xl">
+        <motion.div
+          variants={itemVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.01 }}
+        >
+          <Stack gap="md" align="center" ta="center">
+            <Title
+              order={2}
+              style={{
+                fontSize: isMobile ? "2rem" : "2.5rem",
+                background:
+                  "linear-gradient(135deg, var(--primary-orange), var(--primary-red))",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                backgroundClip: "text",
+              }}
+            >
+              {t.workshopsOverview.title}
+            </Title>
+            <Text size="lg" c="var(--text-secondary)" maw="700px">
+              {t.workshopsOverview.subtitle}
+            </Text>
+          </Stack>
+        </motion.div>
+
+        <Grid
+          cols={{ mobile: 1, tablet: 1, desktop: 2 }}
+          spacing={isMobile ? "md" : "xl"}
+        >
+          {t.workshopsOverview.workshops.map((workshop, index: number) => (
+            <motion.div
+              key={index}
+              variants={cardVariants}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.01 }}
+              transition={{ delay: index * 0.15 }}
+              whileHover={
+                shouldReduceMotion
+                  ? {}
+                  : {
+                      y: -8,
+                      transition: { duration: 0.3 },
+                    }
+              }
+            >
+              <Card
+                shadow="sm"
+                padding="xl"
+                radius="lg"
+                withBorder
+                style={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  borderColor: workshop.available
+                    ? "var(--primary-orange)"
+                    : "var(--border-color)",
+                  cursor: "default",
+                  backgroundColor: "var(--background-primary)",
+                  transition: "border-color 0.3s ease, box-shadow 0.3s ease",
+                  position: "relative",
+                }}
+                styles={{
+                  root: {
+                    "&:hover": {
+                      borderColor: "var(--primary-orange)",
+                      boxShadow: "0 10px 30px var(--shadow-color)",
+                    },
+                  },
+                }}
+              >
+                {workshop.comingSoon && (
+                  <Badge
+                    color="orange"
+                    variant="filled"
+                    size="lg"
+                    style={{
+                      position: "absolute",
+                      top: "1rem",
+                      right: "1rem",
+                    }}
+                  >
+                    Coming Soon
+                  </Badge>
+                )}
+
+                <Stack gap="lg" style={{ flex: 1 }}>
+                  <Stack gap="xs">
+                    <Title order={3} c="var(--text-primary)">
+                      {workshop.title}
+                    </Title>
+                    <Box
+                      style={{
+                        display: "flex",
+                        gap: "0.5rem",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Badge color="blue" variant="light" size="sm">
+                        {workshop.type}
+                      </Badge>
+                      <Badge color="gray" variant="light" size="sm">
+                        {workshop.duration}
+                      </Badge>
+                    </Box>
+                  </Stack>
+
+                  <Text
+                    c="var(--text-secondary)"
+                    style={{ lineHeight: 1.6, textAlign: "justify" }}
+                  >
+                    {workshop.description}
+                  </Text>
+
+                  <List
+                    spacing="xs"
+                    size="sm"
+                    icon={
+                      <ThemeIcon color="green" size={20} radius="xl">
+                        <IconCheck size={12} />
+                      </ThemeIcon>
+                    }
+                  >
+                    {workshop.highlights.map(
+                      (highlight: string, highlightIndex: number) => (
+                        <List.Item key={highlightIndex}>{highlight}</List.Item>
+                      )
+                    )}
+                  </List>
+
+                  <Box style={{ marginTop: "auto" }}>
+                    {workshop.available ? (
+                      <CtaButton
+                        variant="card"
+                        component="a"
+                        href={workshop.link}
+                        fullWidth
+                      >
+                        {workshop.cta}
+                      </CtaButton>
+                    ) : (
+                      <Button
+                        size="md"
+                        fullWidth
+                        variant="outline"
+                        color="orange"
+                        onClick={handleContactClick}
+                      >
+                        {workshop.cta}
+                      </Button>
+                    )}
+                  </Box>
+                </Stack>
+              </Card>
+            </motion.div>
+          ))}
+        </Grid>
+      </Stack>
+    </Section>
+  );
+};


### PR DESCRIPTION
## Summary
- Create reusable CtaButton component to consolidate CTA button styling and behavior
- Support 4 variants: desktop, mobile, hero, and card
- Integrate component in Navigation, Hero, and WorkshopsOverview

## Changes
- **New Component**: `src/components/CtaButton.tsx` with flexible props for different use cases
- **Navigation**: Replace inline CTA buttons with CtaButton component (desktop & mobile)
- **Hero**: Replace contact button with CtaButton component
- **WorkshopsOverview**: Replace workshop CTA with CtaButton component
- **Tests**: Add comprehensive test coverage for WorkshopsOverview

## Benefits
- Consistent CTA button styling across the application
- Single source of truth for button behavior
- Easier maintenance and updates
- Supports customization through props (children, leftSection, size, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)