### PR TITLE
feat: add Xing profile link to contact section

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -15,6 +15,7 @@ import {
   IconBrandGithub,
   IconBrandLinkedin,
   IconBrandStackoverflow,
+  IconBrandXing,
   IconMail,
   IconMapPin,
   IconPhone,
@@ -87,6 +88,11 @@ export const Contact = () => {
       icon: IconBrandLinkedin,
       label: "LinkedIn",
       href: "https://www.linkedin.com/in/johannes-herrmann-795550128/",
+    },
+    {
+      icon: IconBrandXing,
+      label: "Xing",
+      href: "https://www.xing.com/profile/Johannes_Herrmann14",
     },
     {
       icon: IconBrandGithub,


### PR DESCRIPTION
## Summary
- Add Xing social profile link next to LinkedIn in the contact section
- Maintain consistent social links structure and styling

## Changes
- **Contact Component**: Added Xing link to socialLinks array between LinkedIn and GitHub
- **Icon Import**: Added IconBrandXing from @tabler/icons-react
- **Profile URL**: https://www.xing.com/profile/Johannes_Herrmann14

## Benefits
- Provides additional professional networking option for German-speaking visitors
- Completes social media profile presence
- Consistent with existing social links layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)